### PR TITLE
[#16] Allow dynamic setting of label length (^LL)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,8 +5,6 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="" />
-        <option name="gradleJvm" value="corretto-21 (2)" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
@@ -2,6 +2,7 @@
 
 package com.sainsburys.k2zpl.builder
 
+import LazyCommand
 import com.sainsburys.k2zpl.command.CustomCommand
 import com.sainsburys.k2zpl.command.Font
 import com.sainsburys.k2zpl.command.ZplCommand
@@ -36,6 +37,10 @@ class ZplBuilder {
 
     fun command(commandString: String) {
         command(CustomCommand(commandString))
+    }
+
+    fun command(commandBlock: () -> ZplCommand) {
+        command(LazyCommand(commandBlock))
     }
 
     fun build() = buildString {

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
@@ -18,3 +18,14 @@ internal data class LabelLength(val length: Int) : ZplCommand {
 fun ZplBuilder.labelLength(length: Int) {
     command(LabelLength(length))
 }
+
+/**
+ * Sets the length of the label by lambda
+ * This allows for lazy evaluation of the length.
+ * @param length lambda with context of the current [ZplBuilder]
+ */
+fun ZplBuilder.labelLength(length: ZplBuilder.() -> Int) {
+    command {
+        LabelLength(length.invoke(this))
+    }
+}

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LazyCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LazyCommand.kt
@@ -1,0 +1,13 @@
+import com.sainsburys.k2zpl.command.ZplCommand
+
+/**
+ * Allow for lazy evaluation of a ZplCommand. This works by
+ * passing in a block that will be executed when [build] is called.
+ */
+internal class LazyCommand(private val commandBlock: () -> ZplCommand) : ZplCommand {
+    override val command: CharSequence get() = ""
+
+    override fun build(stringBuilder: StringBuilder): StringBuilder {
+        return commandBlock.invoke().build(stringBuilder)
+    }
+}

--- a/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
@@ -32,6 +32,13 @@ class ZplBuilderTest : DescribeSpec({
             subject.command("another-command")
             subject.build() shouldBe "another-command\n"
         }
+        it("should add lambda command") {
+            subject.command {
+                mockZplCommand
+            }
+            subject.build()
+            verify { mockZplCommand.build(ofType()) }
+        }
     }
     describe("dpiSetting") {
         it("throws an appropriate exception when Unset") {

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/LabelLengthTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/LabelLengthTest.kt
@@ -39,5 +39,15 @@ class LabelLengthTest : DescribeSpec({
             }
             result shouldBe "^LL1000\n"
         }
+        it("outputs correct command when using lambda") {
+            var size = 100
+            val result = k2zpl {
+                labelLength {
+                    size
+                }
+                size += 100
+            }
+            result shouldBe "^LL200\n"
+        }
     }
 })

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/LazyCommandTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/LazyCommandTest.kt
@@ -1,0 +1,30 @@
+package com.sainsburys.k2zpl.command
+
+import LazyCommand
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.verify
+
+class LazyCommandTest : DescribeSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val mockZplCommand = mockk<ZplCommand>(relaxed = true)
+
+    describe("LazyCommand") {
+        it("has no command") {
+            val lazyCommand = LazyCommand { mockZplCommand }
+            lazyCommand.command shouldBe ""
+        }
+        it("invokes build against lambda") {
+            val lambda: () -> ZplCommand = {
+                mockZplCommand
+            }
+            val lazyCommand = LazyCommand(lambda)
+            val stringBuilder: StringBuilder = StringBuilder()
+            lazyCommand.build(stringBuilder)
+            verify { mockZplCommand.build(stringBuilder) }
+        }
+    }
+})


### PR DESCRIPTION
Adds `LazyCommand` to support delayed evaluation of a command until `build` is called.

Also add `labelLength` overload function that accepts a lambda.