### PR TITLE
[#15] Replace newlines with ZPL equivalent

### DIFF
--- a/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
@@ -20,7 +20,7 @@ internal data class BarCode(
     }
 
     override val command: CharSequence = "^B1"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "o" to orientation.code,
         "c" to checkDigit.toString(),
         "h" to height,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
@@ -58,7 +58,7 @@ fun ZplBuilder.fieldBlock(
  * @param x horizontal position of fieldBlock
  * @param y vertical position of fieldBlock
  * @param width The width of the text block.
- * @param data content of block
+ * @param data content of block. Any newlines are substituted with \&
  * @param maxLines The number of lines in the text block.
  * @param lineSpacing The space between lines.
  * @param alignment The text alignment within the block.
@@ -82,6 +82,6 @@ fun ZplBuilder.fieldBlock(
         alignment = alignment,
         hangingIndent = hangingIndent
     )
-    fieldData(data)
+    fieldData(data, replaceNewlines = true)
     fieldSeparator()
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
@@ -18,7 +18,7 @@ internal data class FieldBlock(
     }
 
     override val command: CharSequence = "^FB"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "w" to width,
         "l" to maxLines,
         "s" to lineSpacing,
@@ -82,6 +82,6 @@ fun ZplBuilder.fieldBlock(
         alignment = alignment,
         hangingIndent = hangingIndent
     )
-    fieldData(data, replaceNewlines = true)
+    fieldData(data)
     fieldSeparator()
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
@@ -2,15 +2,33 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class FieldData(val data: String) : ZplCommand {
+internal data class FieldData(val data: String, val replaceNewlines: Boolean = false) : ZplCommand {
     override val command: CharSequence = "^FD"
     override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf("d" to data)
+
+    override fun build(stringBuilder: StringBuilder): StringBuilder {
+        return with(stringBuilder) {
+            append(command)
+            append(
+                (parameters["d"] as? CharSequence).convertNewlinesIf(replaceNewlines)
+            )
+        }
+    }
+
+    private fun CharSequence?.convertNewlinesIf(replaceNewlines: Boolean): String {
+        return when {
+            this == null -> ""
+            replaceNewlines -> toString().replace("\n", "\\&")
+            else -> toString()
+        }
+    }
 }
 
 /**
  * Adds field data.
  * @param data The data to be added to the field.
+ * @param replaceNewlines set to true to replace \n with ZPL newline character (\&)
  */
-fun ZplBuilder.fieldData(data: String) {
-    command(FieldData(data))
+fun ZplBuilder.fieldData(data: String, replaceNewlines: Boolean = false) {
+    command(FieldData(data, replaceNewlines))
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
@@ -2,24 +2,22 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class FieldData(val data: String, val replaceNewlines: Boolean = false) : ZplCommand {
+internal data class FieldData(val data: String) : ZplCommand {
     override val command: CharSequence = "^FD"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf("d" to data)
+    override val parameters: Map<CharSequence, Any?> = addParameters("d" to data)
 
     override fun build(stringBuilder: StringBuilder): StringBuilder {
-        return with(stringBuilder) {
-            append(command)
-            append(
-                (parameters["d"] as? CharSequence).convertNewlinesIf(replaceNewlines)
+        return stringBuilder
+            .append(command)
+            .append(
+                (parameters["d"] as? CharSequence).convertNewlines()
             )
-        }
     }
 
-    private fun CharSequence?.convertNewlinesIf(replaceNewlines: Boolean): String {
+    private fun CharSequence?.convertNewlines(): String {
         return when {
             this == null -> ""
-            replaceNewlines -> toString().replace("\n", "\\&")
-            else -> toString()
+            else -> toString().replace("\n", "\\&")
         }
     }
 }
@@ -27,8 +25,7 @@ internal data class FieldData(val data: String, val replaceNewlines: Boolean = f
 /**
  * Adds field data.
  * @param data The data to be added to the field.
- * @param replaceNewlines set to true to replace \n with ZPL newline character (\&)
  */
-fun ZplBuilder.fieldData(data: String, replaceNewlines: Boolean = false) {
-    command(FieldData(data, replaceNewlines))
+fun ZplBuilder.fieldData(data: String) {
+    command(FieldData(data))
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
@@ -14,11 +14,11 @@ internal data class FieldOrigin(
     }
 
     override val command: CharSequence = "^FO"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = buildLinkedMap {
-        put("x", x)
-        put("y", y)
-        put("j", justification)
-    }
+    override val parameters: Map<CharSequence, Any?> = addParameters(
+        "x" to x,
+        "y" to y,
+        "j" to justification
+    )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
@@ -18,7 +18,7 @@ internal data class Font(
 
     override val command: CharSequence = "^A${font}"
     override val parameters: Map<CharSequence, Any?> =
-        linkedMapOf("o" to orientation, "h" to height, "w" to width)
+        addParameters("o" to orientation, "h" to height, "w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
@@ -17,7 +17,7 @@ internal data class Font(
     }
 
     override val command: CharSequence = "^A${font}"
-    override val parameters: LinkedHashMap<CharSequence, Any?> =
+    override val parameters: Map<CharSequence, Any?> =
         linkedMapOf("o" to orientation, "h" to height, "w" to width)
 }
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
@@ -18,12 +18,13 @@ internal data class GraphicBox(
     }
 
     override val command: CharSequence = "^GB"
-    override val parameters: LinkedHashMap<CharSequence, Any?> =
-        buildLinkedMap {
-            putAll(
-                mapOf("w" to width, "h" to height, "t" to thickness, "c" to color.code, "r" to rounding)
-            )
-        }
+    override val parameters: Map<CharSequence, Any?> =
+        linkedMapOf(
+            "w" to width,
+            "h" to height,
+            "t" to thickness, "c" to color.code,
+            "r" to rounding
+        )
 }
 
 /**
@@ -41,13 +42,15 @@ fun ZplBuilder.graphicBox(
     color: ZplLineColor = ZplLineColor.BLACK,
     rounding: Int = 0
 ) {
-    command(GraphicBox(
-        width = width,
-        height = height,
-        thickness = thickness,
-        color = color,
-        rounding = rounding
-    ))
+    command(
+        GraphicBox(
+            width = width,
+            height = height,
+            thickness = thickness,
+            color = color,
+            rounding = rounding
+        )
+    )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
@@ -19,7 +19,7 @@ internal data class GraphicBox(
 
     override val command: CharSequence = "^GB"
     override val parameters: Map<CharSequence, Any?> =
-        linkedMapOf(
+        addParameters(
             "w" to width,
             "h" to height,
             "t" to thickness, "c" to color.code,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
@@ -17,7 +17,7 @@ internal data class GraphicField(
     }
 
     override val command: CharSequence = "^GF"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "f" to format,
         "db" to dataBytes,
         "tb" to totalBytes,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
@@ -4,7 +4,7 @@ import com.sainsburys.k2zpl.builder.ZplBuilder
 
 internal data class LabelHome(val x: Int, val y: Int) : ZplCommand {
     override val command: CharSequence = "^LH"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf("x" to x, "y" to y)
+    override val parameters: Map<CharSequence, Any?> = addParameters("x" to x, "y" to y)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
@@ -8,7 +8,7 @@ internal data class LabelLength(val length: Int) : ZplCommand {
     }
 
     override val command: CharSequence = "^LL"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf("l" to length)
+    override val parameters: Map<CharSequence, Any?> = addParameters("l" to length)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
@@ -10,7 +10,7 @@ internal data class MediaMode(
     val prePeelSelect: ZplYesNo
 ) : ZplCommand {
     override val command: CharSequence = "^MM"
-    override val parameters: LinkedHashMap<CharSequence, Any?> =
+    override val parameters: Map<CharSequence, Any?> =
         linkedMapOf("m" to mediaMode, "p" to prePeelSelect)
 }
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
@@ -11,7 +11,7 @@ internal data class MediaMode(
 ) : ZplCommand {
     override val command: CharSequence = "^MM"
     override val parameters: Map<CharSequence, Any?> =
-        linkedMapOf("m" to mediaMode, "p" to prePeelSelect)
+        addParameters("m" to mediaMode, "p" to prePeelSelect)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
@@ -8,7 +8,7 @@ internal data class PrintWidth(val width: Int) : ZplCommand {
     }
 
     override val command: CharSequence = "^PW"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf("w" to width)
+    override val parameters: Map<CharSequence, Any?> = addParameters("w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 interface ZplCommand {
     val command: CharSequence
-    val parameters: Map<CharSequence, Any?> get() = linkedMapOf()
+    val parameters: Map<CharSequence, Any?> get() = addParameters()
     fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
         with(parameters.values.iterator()) {

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 interface ZplCommand {
     val command: CharSequence
-    val parameters: LinkedHashMap<CharSequence, Any?> get() = linkedMapOf()
+    val parameters: Map<CharSequence, Any?> get() = linkedMapOf()
     fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
         with(parameters.values.iterator()) {
@@ -25,5 +25,8 @@ private fun <T> Iterator<T>.nextNotNull(block: (T) -> Unit) {
     next()?.let { block(it) }
 }
 
-internal fun <K, V> buildLinkedMap(block: LinkedHashMap<K, V>.() -> Unit) =
-    linkedMapOf<K, V>().apply(block)
+/**
+ * A shortcut to adding parameters that helps to enforce use of [LinkedHashMap]
+ * so that entry order is preserved.
+ */
+internal fun <K, V> ZplCommand.addParameters(vararg pairs: Pair<K, V>) = linkedMapOf(*pairs)

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/FieldDataTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/FieldDataTest.kt
@@ -23,46 +23,23 @@ class FieldDataTest : DescribeSpec({
             }
             result shouldBe "^FDsome-other-data\n"
         }
-        context("replaceNewLines is false") {
-            it("outputs correct command using raw string") {
-                val result = k2zpl {
-                    val data =
-                        """
+        it("outputs correct command using raw string") {
+            val result = k2zpl {
+                val data =
+                    """
                     some data
                     with line breaks
                 
                 """.trimIndent()
-                    fieldData(data = data)
-                }
-                result shouldBe "^FDsome data\nwith line breaks\n\n"
+                fieldData(data = data)
             }
-            it("outputs correct command using string") {
-                val result = k2zpl {
-                    fieldData(data = "some data\nwith line breaks\n")
-                }
-                result shouldBe "^FDsome data\nwith line breaks\n\n"
-            }
-
+            result shouldBe "^FDsome data\\&with line breaks\\&\n"
         }
-        context("replaceNewLines is true") {
-            it("outputs correct command using raw string") {
-                val result = k2zpl {
-                    val data =
-                        """
-                    some data
-                    with line breaks
-                
-                """.trimIndent()
-                    fieldData(data = data, replaceNewlines = true)
-                }
-                result shouldBe "^FDsome data\\&with line breaks\\&\n"
+        it("outputs correct command using string") {
+            val result = k2zpl {
+                fieldData(data = "some data\nwith line breaks\n")
             }
-            it("outputs correct command using string") {
-                val result = k2zpl {
-                    fieldData(data = "some data\nwith line breaks\n", replaceNewlines = true)
-                }
-                result shouldBe "^FDsome data\\&with line breaks\\&\n"
-            }
+            result shouldBe "^FDsome data\\&with line breaks\\&\n"
         }
     }
 })

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/FieldDataTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/FieldDataTest.kt
@@ -23,5 +23,46 @@ class FieldDataTest : DescribeSpec({
             }
             result shouldBe "^FDsome-other-data\n"
         }
+        context("replaceNewLines is false") {
+            it("outputs correct command using raw string") {
+                val result = k2zpl {
+                    val data =
+                        """
+                    some data
+                    with line breaks
+                
+                """.trimIndent()
+                    fieldData(data = data)
+                }
+                result shouldBe "^FDsome data\nwith line breaks\n\n"
+            }
+            it("outputs correct command using string") {
+                val result = k2zpl {
+                    fieldData(data = "some data\nwith line breaks\n")
+                }
+                result shouldBe "^FDsome data\nwith line breaks\n\n"
+            }
+
+        }
+        context("replaceNewLines is true") {
+            it("outputs correct command using raw string") {
+                val result = k2zpl {
+                    val data =
+                        """
+                    some data
+                    with line breaks
+                
+                """.trimIndent()
+                    fieldData(data = data, replaceNewlines = true)
+                }
+                result shouldBe "^FDsome data\\&with line breaks\\&\n"
+            }
+            it("outputs correct command using string") {
+                val result = k2zpl {
+                    fieldData(data = "some data\nwith line breaks\n", replaceNewlines = true)
+                }
+                result shouldBe "^FDsome data\\&with line breaks\\&\n"
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
@@ -33,14 +33,14 @@ class ZplCommandWithoutParameters : ZplCommand {
 
 class ZplCommandWithOneParameter : ZplCommand {
     override val command = "^ZCP"
-    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "param-one" to "value-one"
     )
 }
 
 class ZplCommandWithMultipleParameters : ZplCommand {
     override val command = "^ZCPS"
-    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "param-one" to "value-one",
         "param-two" to "value-two"
     )
@@ -48,7 +48,7 @@ class ZplCommandWithMultipleParameters : ZplCommand {
 
 class ZplCommandWitNullFirstParameter : ZplCommand {
     override val command = "^ZCPN"
-    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "param-one" to null,
         "param-two" to "value-two"
     )
@@ -56,7 +56,7 @@ class ZplCommandWitNullFirstParameter : ZplCommand {
 
 class ZplCommandWitNullSecondParameter : ZplCommand {
     override val command = "^ZCPNS"
-    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+    override val parameters: Map<CharSequence, Any?> = addParameters(
         "param-one" to "value-one",
         "param-two" to null
     )

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
@@ -33,28 +33,31 @@ class ZplCommandWithoutParameters : ZplCommand {
 
 class ZplCommandWithOneParameter : ZplCommand {
     override val command = "^ZCP"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = buildLinkedMap {
-        putAll(mapOf("param-one" to "value-one"))
-    }
+    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+        "param-one" to "value-one"
+    )
 }
 
 class ZplCommandWithMultipleParameters : ZplCommand {
     override val command = "^ZCPS"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = buildLinkedMap {
-        putAll(mapOf("param-one" to "value-one", "param-two" to "value-two"))
-    }
+    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+        "param-one" to "value-one",
+        "param-two" to "value-two"
+    )
 }
 
 class ZplCommandWitNullFirstParameter : ZplCommand {
     override val command = "^ZCPN"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = buildLinkedMap {
-        putAll(mapOf("param-one" to null, "param-two" to "value-two"))
-    }
+    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+        "param-one" to null,
+        "param-two" to "value-two"
+    )
 }
 
 class ZplCommandWitNullSecondParameter : ZplCommand {
     override val command = "^ZCPNS"
-    override val parameters: LinkedHashMap<CharSequence, Any?> = buildLinkedMap {
-        putAll(mapOf("param-one" to "value-one", "param-two" to null))
-    }
+    override val parameters: Map<CharSequence, Any?> = linkedMapOf(
+        "param-one" to "value-one",
+        "param-two" to null
+    )
 }


### PR DESCRIPTION
In FieldData, add an option to replace newlines `\n` with ZPL newline representation `\&`.

Also update FieldBlock extension to use this option so that any usage of fieldBlock will automatically replace newlines.