### PR TITLE
Enforce immutability and insertion iteration order properties of ZplCommand.parameters

### DIFF
--- a/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
@@ -13,20 +13,21 @@ internal data class BarCode(
     val height: Int,
     val line: Int,
     val lineAbove: ZplYesNo
-) : ZplCommand {
-    init {
-        require(height in 1..32000) { "Height must be between 1 and 32000" }
-        require(line in 1..7) { "Line thickness must be between 1 and 7" }
-    }
-
-    override val command: CharSequence = "^B1"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+) : ZplCommand(
+    parameters = listOf(
         "o" to orientation.code,
         "c" to checkDigit.toString(),
         "h" to height,
         "l" to line,
         "la" to lineAbove.toString()
     )
+) {
+    init {
+        require(height in 1..32000) { "Height must be between 1 and 32000" }
+        require(line in 1..7) { "Line thickness must be between 1 and 7" }
+    }
+
+    override val command: CharSequence = "^B1"
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/CustomCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/CustomCommand.kt
@@ -1,3 +1,3 @@
 package com.sainsburys.k2zpl.command
 
-internal data class CustomCommand(override val command: CharSequence) : ZplCommand
+internal data class CustomCommand(override val command: CharSequence) : ZplCommand()

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/EndFormat.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/EndFormat.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data object EndFormat : ZplCommand {
+internal data object EndFormat : ZplCommand() {
     override val command: CharSequence = "^XZ"
 }
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
@@ -9,7 +9,15 @@ internal data class FieldBlock(
     val lineSpacing: Int,
     val alignment: ZplTextAlignment,
     val hangingIndent: Int
-) : ZplCommand {
+) : ZplCommand(
+    parameters = listOf(
+        "w" to width,
+        "l" to maxLines,
+        "s" to lineSpacing,
+        "a" to alignment.code,
+        "h" to hangingIndent
+    )
+) {
     init {
         require(width in 1..32000) { "Width must be between 1 and 32000" }
         require(maxLines in 1..9999) { "Lines must be between 1 and 9999" }
@@ -18,13 +26,6 @@ internal data class FieldBlock(
     }
 
     override val command: CharSequence = "^FB"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
-        "w" to width,
-        "l" to maxLines,
-        "s" to lineSpacing,
-        "a" to alignment.code,
-        "h" to hangingIndent
-    )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
@@ -2,9 +2,11 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class FieldData(val data: String) : ZplCommand {
+internal data class FieldData(val data: String) : ZplCommand(
+    parameters = listOf("d" to data)
+) {
+
     override val command: CharSequence = "^FD"
-    override val parameters: Map<CharSequence, Any?> = addParameters("d" to data)
 
     override fun build(stringBuilder: StringBuilder): StringBuilder {
         return stringBuilder

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
@@ -7,18 +7,19 @@ internal data class FieldOrigin(
     val x: Int,
     val y: Int,
     val justification: ZplJustification
-) : ZplCommand {
+) : ZplCommand(
+    parameters = listOf(
+        "x" to x,
+        "y" to y,
+        "j" to justification
+    )
+) {
     init {
         require(x in 0..32000) { "x must be within 0 to 32000" }
         require(y in 0..32000) { "y must be within 0 to 32000" }
     }
 
     override val command: CharSequence = "^FO"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
-        "x" to x,
-        "y" to y,
-        "j" to justification
-    )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldSeparator.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldSeparator.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data object FieldSeparator : ZplCommand {
+internal data object FieldSeparator : ZplCommand() {
     override val command: CharSequence = "^FS"
 }
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
@@ -9,16 +9,17 @@ internal data class Font(
     val orientation: ZplFieldOrientation,
     val height: Int,
     val width: Int
-) :
-    ZplCommand {
+) : ZplCommand(
+    parameters = listOf(
+        "o" to orientation, "h" to height, "w" to width
+    )
+) {
     init {
         require(height in 10..32000) { "Height must be between 10 and 32000" }
         require(width in 10..32000) { "Width must be between 10 and 32000" }
     }
 
     override val command: CharSequence = "^A${font}"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters("o" to orientation, "h" to height, "w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
@@ -9,7 +9,14 @@ internal data class GraphicBox(
     val thickness: Int = 1,
     val color: ZplLineColor = ZplLineColor.BLACK,
     val rounding: Int = 0
-) : ZplCommand {
+) : ZplCommand(
+    parameters = listOf(
+        "w" to width,
+        "h" to height,
+        "t" to thickness, "c" to color.code,
+        "r" to rounding
+    )
+) {
     init {
         require(width in 1..32000) { "Width must be between 1 and 32000" }
         require(height in 1..32000) { "Height must be between 1 and 32000" }
@@ -18,13 +25,6 @@ internal data class GraphicBox(
     }
 
     override val command: CharSequence = "^GB"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters(
-            "w" to width,
-            "h" to height,
-            "t" to thickness, "c" to color.code,
-            "r" to rounding
-        )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
@@ -9,7 +9,15 @@ internal data class GraphicField(
     val totalBytes: Int,
     val rowBytes: Int,
     val data: String
-) : ZplCommand {
+) : ZplCommand(
+    parameters = listOf(
+        "f" to format,
+        "db" to dataBytes,
+        "tb" to totalBytes,
+        "rb" to rowBytes,
+        "d" to data
+    )
+) {
     init {
         require(dataBytes in 1..999999) { "Data bytes must be between 1 and 999999" }
         require(totalBytes in 1..999999) { "Total bytes must be between 1 and 999999" }
@@ -17,13 +25,6 @@ internal data class GraphicField(
     }
 
     override val command: CharSequence = "^GF"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
-        "f" to format,
-        "db" to dataBytes,
-        "tb" to totalBytes,
-        "rb" to rowBytes,
-        "d" to data
-    )
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
@@ -2,9 +2,10 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class LabelHome(val x: Int, val y: Int) : ZplCommand {
+internal data class LabelHome(val x: Int, val y: Int) : ZplCommand(
+    parameters = listOf("x" to x, "y" to y)
+) {
     override val command: CharSequence = "^LH"
-    override val parameters: Map<CharSequence, Any?> = addParameters("x" to x, "y" to y)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
@@ -2,13 +2,14 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class LabelLength(val length: Int) : ZplCommand {
+internal data class LabelLength(val length: Int) : ZplCommand(
+    parameters = listOf("l" to length)
+) {
     init {
         require(length in 1..32000) { "Length must be between 1 and 32000" }
     }
 
     override val command: CharSequence = "^LL"
-    override val parameters: Map<CharSequence, Any?> = addParameters("l" to length)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LazyCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LazyCommand.kt
@@ -4,7 +4,7 @@ package com.sainsburys.k2zpl.command
  * Allow for lazy evaluation of a ZplCommand. This works by
  * passing in a block that will be executed when [build] is called.
  */
-internal class LazyCommand(private val commandBlock: () -> ZplCommand) : ZplCommand {
+internal class LazyCommand(private val commandBlock: () -> ZplCommand) : ZplCommand() {
     override val command: CharSequence get() = ""
 
     override fun build(stringBuilder: StringBuilder): StringBuilder {

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
@@ -8,10 +8,10 @@ import com.sainsburys.k2zpl.command.options.ZplYesNo
 internal data class MediaMode(
     val mediaMode: ZplMediaMode,
     val prePeelSelect: ZplYesNo
-) : ZplCommand {
+) : ZplCommand(
+    parameters = listOf("m" to mediaMode, "p" to prePeelSelect)
+) {
     override val command: CharSequence = "^MM"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters("m" to mediaMode, "p" to prePeelSelect)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
@@ -2,13 +2,14 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data class PrintWidth(val width: Int) : ZplCommand {
+internal data class PrintWidth(val width: Int) : ZplCommand(
+    parameters = listOf("w" to width)
+) {
     init {
         require(width in 2 .. 32000) { "Width must be greater than 2. Value is also capped at width of the actual label." }
     }
 
     override val command: CharSequence = "^PW"
-    override val parameters: Map<CharSequence, Any?> = addParameters("w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/StartFormat.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/StartFormat.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 
-internal data object StartFormat : ZplCommand {
+internal data object StartFormat : ZplCommand() {
     override val command: CharSequence = "^XA"
 }
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -1,9 +1,15 @@
 package com.sainsburys.k2zpl.command
 
-interface ZplCommand {
-    val command: CharSequence
-    val parameters: Map<CharSequence, Any?> get() = addParameters()
-    fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
+import java.util.Collections.unmodifiableMap
+
+abstract class ZplCommand(
+    parameters: List<Pair<CharSequence, Any?>> = emptyList()
+) {
+    val parameters: Map<CharSequence, Any?> = unmodifiableMap(parameters.toMap())
+
+    abstract val command: CharSequence
+
+    open fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
         with(parameters.values.iterator()) {
             if (hasNext()) {
@@ -24,9 +30,3 @@ interface ZplCommand {
 private fun <T> Iterator<T>.nextNotNull(block: (T) -> Unit) {
     next()?.let { block(it) }
 }
-
-/**
- * A shortcut to adding parameters that helps to enforce use of [LinkedHashMap]
- * so that entry order is preserved.
- */
-internal fun <K, V> ZplCommand.addParameters(vararg pairs: Pair<K, V>) = linkedMapOf(*pairs)

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
@@ -27,37 +27,39 @@ class ZplCommandTest : DescribeSpec({
     }
 })
 
-class ZplCommandWithoutParameters : ZplCommand {
+class ZplCommandWithoutParameters : ZplCommand() {
     override val command = "^ZC"
 }
 
-class ZplCommandWithOneParameter : ZplCommand {
+class ZplCommandWithOneParameter : ZplCommand(
+    parameters = listOf("param-one" to "value-one")
+) {
     override val command = "^ZCP"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
-        "param-one" to "value-one"
-    )
 }
 
-class ZplCommandWithMultipleParameters : ZplCommand {
-    override val command = "^ZCPS"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+class ZplCommandWithMultipleParameters : ZplCommand(
+    parameters = listOf(
         "param-one" to "value-one",
         "param-two" to "value-two"
     )
+) {
+    override val command = "^ZCPS"
 }
 
-class ZplCommandWitNullFirstParameter : ZplCommand {
-    override val command = "^ZCPN"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+class ZplCommandWitNullFirstParameter : ZplCommand(
+    parameters = listOf(
         "param-one" to null,
         "param-two" to "value-two"
     )
+) {
+    override val command = "^ZCPN"
 }
 
-class ZplCommandWitNullSecondParameter : ZplCommand {
-    override val command = "^ZCPNS"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+class ZplCommandWitNullSecondParameter : ZplCommand(
+    parameters = listOf(
         "param-one" to "value-one",
         "param-two" to null
     )
+) {
+    override val command = "^ZCPNS"
 }


### PR DESCRIPTION
This PR is a follow-up to #18.

In #18, I [described](https://github.com/sainsburys-tech/k2zpl/pull/18#discussion_r1749883389) a way of eliminating the need to make `parameters` a `LinkedHashMap` publicly without losing insertion iteration ordering.

This PR is a bit different to how I described it, but the main change is that `ZplCommand` becomes an abstract class whose constructor accepts a list of ZPL parameters to enforce insertion ordering, and `ZplCommand.parameters` becomes an unmodifiable map of these parameters.

**Advantages**

1. People can't accidentally do the following:
    ```kotlin
    override val parameters: Map<CharSequence, Any?> = hashMapOf()
    ```
    ...which loses insertion ordering.

2. People can't be naughty and do this:
    ```kotlin
    val barCode = BarCode(...)
    
    (barCode.parameters as MutableMap<CharSequence, Any?>)["foo"] = "bar"
    ```
    ...since it now throws an `UnsupportedOperationException`. This is due to the use of `java.util.Collections.unmodifiableMap`.

**Drawbacks**
1. `ZplCommand` is changed in a backwards-incompatible way, but this is probably fine as we're still on version 0.x.
2. It's arguable if `java.util.Collections.unmodifiableMap` is necessary. On one hand, it guards against Kotlin's read-only collections being able to be casted into mutable collections. On the other hand, it's Java-specific (though we're targeting JVM/Android anyway) and it's not idiomatic in Kotlin.

Thoughts?