### PR TITLE
[CHORE] Add ZplParameters Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/misc.xml
 *.iws
 *.iml
 *.ipr

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/BarCode.kt
@@ -20,7 +20,7 @@ internal data class BarCode(
     }
 
     override val command: CharSequence = "^B1"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "o" to orientation.code,
         "c" to checkDigit.toString(),
         "h" to height,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldBlock.kt
@@ -18,7 +18,7 @@ internal data class FieldBlock(
     }
 
     override val command: CharSequence = "^FB"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "w" to width,
         "l" to maxLines,
         "s" to lineSpacing,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldData.kt
@@ -4,7 +4,7 @@ import com.sainsburys.k2zpl.builder.ZplBuilder
 
 internal data class FieldData(val data: String) : ZplCommand {
     override val command: CharSequence = "^FD"
-    override val parameters: Map<CharSequence, Any?> = addParameters("d" to data)
+    override val parameters: ZplParameters = zplParameters("d" to data)
 
     override fun build(stringBuilder: StringBuilder): StringBuilder {
         return stringBuilder

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/FieldOrigin.kt
@@ -14,7 +14,7 @@ internal data class FieldOrigin(
     }
 
     override val command: CharSequence = "^FO"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "x" to x,
         "y" to y,
         "j" to justification

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/Font.kt
@@ -17,8 +17,8 @@ internal data class Font(
     }
 
     override val command: CharSequence = "^A${font}"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters("o" to orientation, "h" to height, "w" to width)
+    override val parameters: ZplParameters =
+        zplParameters("o" to orientation, "h" to height, "w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicBox.kt
@@ -18,8 +18,8 @@ internal data class GraphicBox(
     }
 
     override val command: CharSequence = "^GB"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters(
+    override val parameters: ZplParameters =
+        zplParameters(
             "w" to width,
             "h" to height,
             "t" to thickness, "c" to color.code,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/GraphicField.kt
@@ -17,7 +17,7 @@ internal data class GraphicField(
     }
 
     override val command: CharSequence = "^GF"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "f" to format,
         "db" to dataBytes,
         "tb" to totalBytes,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelHome.kt
@@ -4,7 +4,7 @@ import com.sainsburys.k2zpl.builder.ZplBuilder
 
 internal data class LabelHome(val x: Int, val y: Int) : ZplCommand {
     override val command: CharSequence = "^LH"
-    override val parameters: Map<CharSequence, Any?> = addParameters("x" to x, "y" to y)
+    override val parameters: ZplParameters = zplParameters("x" to x, "y" to y)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
@@ -8,7 +8,7 @@ internal data class LabelLength(val length: Int) : ZplCommand {
     }
 
     override val command: CharSequence = "^LL"
-    override val parameters: Map<CharSequence, Any?> = addParameters("l" to length)
+    override val parameters: ZplParameters = zplParameters("l" to length)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/MediaMode.kt
@@ -10,8 +10,8 @@ internal data class MediaMode(
     val prePeelSelect: ZplYesNo
 ) : ZplCommand {
     override val command: CharSequence = "^MM"
-    override val parameters: Map<CharSequence, Any?> =
-        addParameters("m" to mediaMode, "p" to prePeelSelect)
+    override val parameters: ZplParameters =
+        zplParameters("m" to mediaMode, "p" to prePeelSelect)
 }
 
 /**

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/PrintWidth.kt
@@ -8,7 +8,7 @@ internal data class PrintWidth(val width: Int) : ZplCommand {
     }
 
     override val command: CharSequence = "^PW"
-    override val parameters: Map<CharSequence, Any?> = addParameters("w" to width)
+    override val parameters: ZplParameters = zplParameters("w" to width)
 }
 
 

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -7,8 +7,8 @@ interface ZplCommand {
         append(command)
         parameters
             .asSequence()
-            .map { parameter -> parameter.value?.toString()?.takeIf { it.isNotBlank() } }
-            .filterNotNull()
+            .mapNotNull { it.value?.toString() }
+            .filter(String::isNotBlank)
             .joinTo(this, separator = ",")
     }
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -5,18 +5,10 @@ interface ZplCommand {
     val parameters: ZplParameters get() = zplParameters()
     fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
-        with(parameters.iterator()) {
-            if (hasNext()) {
-                next().value?.let { append(it.toString()) }
-            }
-            while (hasNext()) {
-                next().value?.let {
-                    if (length > command.length) {
-                        append(',')
-                    }
-                    append(it.toString())
-                }
-            }
-        }
+        parameters
+            .asSequence()
+            .map { parameter -> parameter.value?.toString()?.takeIf { it.isNotBlank() } }
+            .filterNotNull()
+            .joinTo(this, separator = ",")
     }
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -5,12 +5,12 @@ interface ZplCommand {
     val parameters: ZplParameters get() = zplParameters()
     fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
-        with(parameters.values.iterator()) {
+        with(parameters.iterator()) {
             if (hasNext()) {
-                nextNotNull { append(it.toString()) }
+                next().value?.let { append(it.toString()) }
             }
             while (hasNext()) {
-                nextNotNull {
+                next().value?.let {
                     if (length > command.length) {
                         append(',')
                     }
@@ -19,8 +19,4 @@ interface ZplCommand {
             }
         }
     }
-}
-
-private fun <T> Iterator<T>.nextNotNull(block: (T) -> Unit) {
-    next()?.let { block(it) }
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplCommand.kt
@@ -2,7 +2,7 @@ package com.sainsburys.k2zpl.command
 
 interface ZplCommand {
     val command: CharSequence
-    val parameters: Map<CharSequence, Any?> get() = addParameters()
+    val parameters: ZplParameters get() = zplParameters()
     fun build(stringBuilder: StringBuilder) = stringBuilder.apply {
         append(command)
         with(parameters.values.iterator()) {
@@ -24,9 +24,3 @@ interface ZplCommand {
 private fun <T> Iterator<T>.nextNotNull(block: (T) -> Unit) {
     next()?.let { block(it) }
 }
-
-/**
- * A shortcut to adding parameters that helps to enforce use of [LinkedHashMap]
- * so that entry order is preserved.
- */
-internal fun <K, V> ZplCommand.addParameters(vararg pairs: Pair<K, V>) = linkedMapOf(*pairs)

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
@@ -1,0 +1,9 @@
+package com.sainsburys.k2zpl.command
+
+class ZplParameters(vararg pairs: Pair<CharSequence, Any?>) {
+    private val _parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf(*pairs)
+    val values get() = _parameters.values
+    operator fun get(key: CharSequence) = _parameters[key]
+}
+
+fun zplParameters(vararg pairs: Pair<CharSequence, Any?>) = ZplParameters(*pairs)

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
@@ -1,7 +1,7 @@
 package com.sainsburys.k2zpl.command
 
 class ZplParameters(map: Map<CharSequence, Any?>) : Iterable<Map.Entry<CharSequence, Any?>> {
-    constructor(vararg pairs: Pair<CharSequence, Any?>) : this(linkedMapOf(*pairs))
+    constructor(vararg pairs: Pair<CharSequence, Any?>) : this(mapOf(*pairs))
     private val _parameters: LinkedHashMap<CharSequence, Any?> = LinkedHashMap(map)
     operator fun get(key: CharSequence) = _parameters[key]
     override fun iterator(): Iterator<Map.Entry<CharSequence, Any?>> =

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/ZplParameters.kt
@@ -1,9 +1,12 @@
 package com.sainsburys.k2zpl.command
 
-class ZplParameters(vararg pairs: Pair<CharSequence, Any?>) {
-    private val _parameters: LinkedHashMap<CharSequence, Any?> = linkedMapOf(*pairs)
-    val values get() = _parameters.values
+class ZplParameters(map: Map<CharSequence, Any?>) : Iterable<Map.Entry<CharSequence, Any?>> {
+    constructor(vararg pairs: Pair<CharSequence, Any?>) : this(linkedMapOf(*pairs))
+    private val _parameters: LinkedHashMap<CharSequence, Any?> = LinkedHashMap(map)
     operator fun get(key: CharSequence) = _parameters[key]
+    override fun iterator(): Iterator<Map.Entry<CharSequence, Any?>> =
+        _parameters.iterator()
 }
 
 fun zplParameters(vararg pairs: Pair<CharSequence, Any?>) = ZplParameters(*pairs)
+fun zplParameters(builderBlock: MutableMap<CharSequence, Any?>.() -> Unit) = ZplParameters(buildMap(builderBlock))

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplCommandTest.kt
@@ -33,14 +33,14 @@ class ZplCommandWithoutParameters : ZplCommand {
 
 class ZplCommandWithOneParameter : ZplCommand {
     override val command = "^ZCP"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "param-one" to "value-one"
     )
 }
 
 class ZplCommandWithMultipleParameters : ZplCommand {
     override val command = "^ZCPS"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "param-one" to "value-one",
         "param-two" to "value-two"
     )
@@ -48,7 +48,7 @@ class ZplCommandWithMultipleParameters : ZplCommand {
 
 class ZplCommandWitNullFirstParameter : ZplCommand {
     override val command = "^ZCPN"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "param-one" to null,
         "param-two" to "value-two"
     )
@@ -56,7 +56,7 @@ class ZplCommandWitNullFirstParameter : ZplCommand {
 
 class ZplCommandWitNullSecondParameter : ZplCommand {
     override val command = "^ZCPNS"
-    override val parameters: Map<CharSequence, Any?> = addParameters(
+    override val parameters: ZplParameters = zplParameters(
         "param-one" to "value-one",
         "param-two" to null
     )

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplParametersTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplParametersTest.kt
@@ -1,0 +1,30 @@
+package com.sainsburys.k2zpl.command
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class ZplParametersTest : DescribeSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    describe("ZplParameters") {
+        val result = ZplParameters("a" to "b", "c" to "d")
+        it("returns values passed to ZplParameters") {
+            result.values shouldBe listOf("b", "d")
+        }
+        it("makes values accessible by get operator") {
+            result["a"] shouldBe "b"
+            result["c"] shouldBe "d"
+        }
+    }
+    describe("zplParameters function") {
+        val result = zplParameters("e" to "f", "g" to "h")
+        it("returns values passed to ZplParameters") {
+            result.values shouldBe listOf("f", "h")
+        }
+        it("makes values accessible by get operator") {
+            result["e"] shouldBe "f"
+            result["g"] shouldBe "h"
+        }
+    }
+})

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/ZplParametersTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/ZplParametersTest.kt
@@ -7,24 +7,67 @@ import io.kotest.matchers.shouldBe
 class ZplParametersTest : DescribeSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
-    describe("ZplParameters") {
+    describe("ZplParameters pairs constructor") {
         val result = ZplParameters("a" to "b", "c" to "d")
         it("returns values passed to ZplParameters") {
-            result.values shouldBe listOf("b", "d")
+            result.forEachIndexed { index, param ->
+                when (index) {
+                    0 -> param.value shouldBe "b"
+                    1 -> param.value shouldBe "d"
+                }
+            }
         }
         it("makes values accessible by get operator") {
             result["a"] shouldBe "b"
             result["c"] shouldBe "d"
         }
     }
-    describe("zplParameters function") {
+    describe("ZplParameters map constructor") {
+        val result = ZplParameters(mapOf("a" to "b", "c" to "d"))
+        it("returns values passed to ZplParameters") {
+            result.forEachIndexed { index, param ->
+                when (index) {
+                    0 -> param.value shouldBe "b"
+                    1 -> param.value shouldBe "d"
+                }
+            }
+        }
+        it("makes values accessible by get operator") {
+            result["a"] shouldBe "b"
+            result["c"] shouldBe "d"
+        }
+    }
+    describe("zplParameters pairs function") {
         val result = zplParameters("e" to "f", "g" to "h")
         it("returns values passed to ZplParameters") {
-            result.values shouldBe listOf("f", "h")
-        }
+            result.forEachIndexed { index, param ->
+                when (index) {
+                    0 -> param.value shouldBe "f"
+                    1 -> param.value shouldBe "h"
+                }
+            }        }
         it("makes values accessible by get operator") {
             result["e"] shouldBe "f"
             result["g"] shouldBe "h"
+        }
+    }
+
+    describe("ZplParameters builder function") {
+        val result = zplParameters {
+            put("a", "b")
+            put("c", "d")
+        }
+        it("returns values passed to ZplParameters") {
+            result.forEachIndexed { index, param ->
+                when (index) {
+                    0 -> param.value shouldBe "b"
+                    1 -> param.value shouldBe "d"
+                }
+            }
+        }
+        it("makes values accessible by get operator") {
+            result["a"] shouldBe "b"
+            result["c"] shouldBe "d"
         }
     }
 })


### PR DESCRIPTION
Makes a wrapper class to enforce usage of `LinkedHashMap` which will preserve key entry order. This is important as `ZplBuilder` expects all `ZplCommand::parameters` to be in the order added.