### PR TITLE
[#14] Update barcode helper

### DIFF
--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode.kt
@@ -1,0 +1,9 @@
+package com.sainsburys.k2zpl.command.barcode
+
+import com.sainsburys.k2zpl.command.ZplCommand
+import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
+
+internal abstract class BarCode : ZplCommand {
+    abstract val orientation: ZplFieldOrientation
+    abstract val height: Int
+}

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode.kt
@@ -3,7 +3,7 @@ package com.sainsburys.k2zpl.command.barcode
 import com.sainsburys.k2zpl.command.ZplCommand
 import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 
-internal abstract class BarCode : ZplCommand {
-    abstract val orientation: ZplFieldOrientation
-    abstract val height: Int
+internal interface BarCode : ZplCommand {
+    val orientation: ZplFieldOrientation
+    val height: Int
 }

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128.kt
@@ -18,7 +18,7 @@ internal data class BarCode128(
     val lineAbove: ZplYesNo,
     val checkDigit: ZplYesNo,
     val mode: ZplBarCode128Mode
-) : BarCode() {
+) : BarCode {
 
     init {
         require(height in 1..32000) { "Height must be between 1 and 32000" }
@@ -41,19 +41,19 @@ internal data class BarCode128(
  * @param data data encoded in the barcode
  * @param x horizontal position
  * @param y vertical position
- * @param orientation The orientation of the barcode.
- * @param height The height of the barcode.
+ * @param orientation The orientation of the barcode
+ * @param height the height of the barcode
  * @param interpretationLine print interpretation line
  * @param lineAbove print interpretation line above code
- * @param checkDigit UCC check digit
+ * @param checkDigit whether to include a UCC check digit
  * @param mode barcode mode
  */
 fun ZplBuilder.barcode128(
     data: String,
     x: Int,
     y: Int,
-    orientation: ZplFieldOrientation = ZplFieldOrientation.NORMAL,
     height: Int,
+    orientation: ZplFieldOrientation = ZplFieldOrientation.NORMAL,
     interpretationLine: Boolean = false,
     lineAbove: Boolean = false,
     checkDigit: Boolean = false,

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128.kt
@@ -1,0 +1,75 @@
+package com.sainsburys.k2zpl.command.barcode
+
+import com.sainsburys.k2zpl.builder.ZplBuilder
+import com.sainsburys.k2zpl.builder.toZplYesNo
+import com.sainsburys.k2zpl.command.ZplParameters
+import com.sainsburys.k2zpl.command.fieldData
+import com.sainsburys.k2zpl.command.fieldOrigin
+import com.sainsburys.k2zpl.command.fieldSeparator
+import com.sainsburys.k2zpl.command.options.ZplBarCode128Mode
+import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
+import com.sainsburys.k2zpl.command.options.ZplYesNo
+import com.sainsburys.k2zpl.command.zplParameters
+
+internal data class BarCode128(
+    override val orientation: ZplFieldOrientation,
+    override val height: Int,
+    val line: ZplYesNo,
+    val lineAbove: ZplYesNo,
+    val checkDigit: ZplYesNo,
+    val mode: ZplBarCode128Mode
+) : BarCode() {
+
+    init {
+        require(height in 1..32000) { "Height must be between 1 and 32000" }
+    }
+
+    override val command = "^BC"
+
+    override val parameters: ZplParameters = zplParameters(
+        "o" to orientation.code,
+        "h" to height,
+        "l" to line,
+        "la" to lineAbove.toString(),
+        "c" to checkDigit.toString(),
+        "m" to mode.toString()
+    )
+}
+
+/**
+ * Creates a Code 128 barcode marker
+ * @param data data encoded in the barcode
+ * @param x horizontal position
+ * @param y vertical position
+ * @param orientation The orientation of the barcode.
+ * @param height The height of the barcode.
+ * @param interpretationLine print interpretation line
+ * @param lineAbove print interpretation line above code
+ * @param checkDigit UCC check digit
+ * @param mode barcode mode
+ */
+fun ZplBuilder.barcode128(
+    data: String,
+    x: Int,
+    y: Int,
+    orientation: ZplFieldOrientation = ZplFieldOrientation.NORMAL,
+    height: Int,
+    interpretationLine: Boolean = false,
+    lineAbove: Boolean = false,
+    checkDigit: Boolean = false,
+    mode: ZplBarCode128Mode = ZplBarCode128Mode.NONE
+) {
+    fieldOrigin(x, y)
+    command(
+        BarCode128(
+            orientation = orientation,
+            height = height,
+            line = interpretationLine.toZplYesNo(),
+            lineAbove = lineAbove.toZplYesNo(),
+            checkDigit = checkDigit.toZplYesNo(),
+            mode = mode
+        )
+    )
+    fieldData(data)
+    fieldSeparator()
+}

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39.kt
@@ -16,7 +16,7 @@ internal data class BarCode39(
     val checkDigit: ZplYesNo,
     val line: ZplYesNo,
     val lineAbove: ZplYesNo,
-) : BarCode() {
+) : BarCode {
 
     init {
         require(height in 1..32000) { "Height must be between 1 and 32000" }
@@ -38,9 +38,9 @@ internal data class BarCode39(
  * @param data data encoded in the barcode
  * @param x horizontal position
  * @param y vertical position
- * @param orientation The orientation of the barcode.
- * @param checkDigit Mod-43 check digit
- * @param height The height of the barcode.
+ * @param orientation the orientation of the barcode.
+ * @param checkDigit whether to include a Mod-43 check digit
+ * @param height the height of the barcode.
  * @param interpretationLine print interpretation line
  * @param lineAbove print interpretation line above code
  */
@@ -48,9 +48,9 @@ fun ZplBuilder.barcode39(
     data: String,
     x: Int,
     y: Int,
+    height: Int,
     orientation: ZplFieldOrientation = ZplFieldOrientation.NORMAL,
     checkDigit: Boolean = false,
-    height: Int,
     interpretationLine: Boolean = false,
     lineAbove: Boolean = false
 ) {

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39.kt
@@ -1,30 +1,34 @@
-package com.sainsburys.k2zpl.command
+package com.sainsburys.k2zpl.command.barcode
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
 import com.sainsburys.k2zpl.builder.toZplYesNo
-import com.sainsburys.k2zpl.command.options.ZplBarcodeType
+import com.sainsburys.k2zpl.command.ZplParameters
+import com.sainsburys.k2zpl.command.fieldData
+import com.sainsburys.k2zpl.command.fieldOrigin
+import com.sainsburys.k2zpl.command.fieldSeparator
 import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 import com.sainsburys.k2zpl.command.options.ZplYesNo
+import com.sainsburys.k2zpl.command.zplParameters
 
-internal data class BarCode(
-    val type: ZplBarcodeType,
-    val orientation: ZplFieldOrientation,
+internal data class BarCode39(
+    override val height: Int,
+    override val orientation: ZplFieldOrientation,
     val checkDigit: ZplYesNo,
-    val height: Int,
-    val line: Int,
-    val lineAbove: ZplYesNo
-) : ZplCommand {
+    val line: ZplYesNo,
+    val lineAbove: ZplYesNo,
+) : BarCode() {
+
     init {
         require(height in 1..32000) { "Height must be between 1 and 32000" }
-        require(line in 1..7) { "Line thickness must be between 1 and 7" }
     }
 
-    override val command: CharSequence = "^B1"
+    override val command = "^B3"
+
     override val parameters: ZplParameters = zplParameters(
         "o" to orientation.code,
         "c" to checkDigit.toString(),
         "h" to height,
-        "l" to line,
+        "l" to line.toString(),
         "la" to lineAbove.toString()
     )
 }
@@ -34,32 +38,29 @@ internal data class BarCode(
  * @param data data encoded in the barcode
  * @param x horizontal position
  * @param y vertical position
- * @param barcodeType Barcode type
  * @param orientation The orientation of the barcode.
- * @param checkDigit Whether to include a check digit.
+ * @param checkDigit Mod-43 check digit
  * @param height The height of the barcode.
- * @param lineThickness The line thickness of the barcode.
- * @param lineAbove Whether to include a line above the barcode.
+ * @param interpretationLine print interpretation line
+ * @param lineAbove print interpretation line above code
  */
-fun ZplBuilder.barcode(
+fun ZplBuilder.barcode39(
     data: String,
     x: Int,
     y: Int,
-    height: Int,
-    lineThickness: Int,
-    barcodeType: ZplBarcodeType = ZplBarcodeType.CODE_39,
     orientation: ZplFieldOrientation = ZplFieldOrientation.NORMAL,
     checkDigit: Boolean = false,
+    height: Int,
+    interpretationLine: Boolean = false,
     lineAbove: Boolean = false
 ) {
     fieldOrigin(x, y)
     command(
-        BarCode(
-            type = barcodeType,
+        BarCode39(
             orientation = orientation,
             checkDigit = checkDigit.toZplYesNo(),
             height = height,
-            line = lineThickness,
+            line = interpretationLine.toZplYesNo(),
             lineAbove = lineAbove.toZplYesNo()
         )
     )

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplBarCode128Mode.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplBarCode128Mode.kt
@@ -1,0 +1,12 @@
+package com.sainsburys.k2zpl.command.options
+
+enum class ZplBarCode128Mode(val value: String) {
+    NONE("N"),
+    UCC("U"),
+    AUTOMATIC("A"),
+    UCC_EAN("D");
+
+    override fun toString(): String {
+        return value
+    }
+}

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplBarcodeType.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplBarcodeType.kt
@@ -1,7 +1,0 @@
-@file:Suppress("UNUSED")
-
-package com.sainsburys.k2zpl.command.options
-
-enum class ZplBarcodeType {
-    CODE_39
-}

--- a/src/test/kotlin/com/sainsburys/k2zpl/Extensions.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/Extensions.kt
@@ -1,5 +1,9 @@
 package com.sainsburys.k2zpl
 
 import com.sainsburys.k2zpl.command.ZplCommand
+import io.kotest.data.row
+import kotlin.enums.EnumEntries
 
 fun ZplCommand.testBuildString() = buildString { build(this) }
+
+inline fun <reified T : Enum<T>> EnumEntries<T>.toRows() = map(::row)

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/FieldBlockTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/FieldBlockTest.kt
@@ -3,6 +3,7 @@ package com.sainsburys.k2zpl.command
 import com.sainsburys.k2zpl.command.options.ZplTextAlignment
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -50,7 +51,7 @@ class FieldBlockTest : DescribeSpec({
             }
         }
         it("uses alignment parameter correctly") {
-            ZplTextAlignment.entries.forEach {
+            table(headers("alignment"), ZplTextAlignment.entries.toRows()).forAll {
                 fieldBlock.copy(alignment = it).testBuildString() shouldBe "^FB10,1,10,$it,0"
             }
         }

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/FieldOriginTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/FieldOriginTest.kt
@@ -3,6 +3,7 @@ package com.sainsburys.k2zpl.command
 import com.sainsburys.k2zpl.command.options.ZplJustification
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -26,7 +27,7 @@ class FieldOriginTest : DescribeSpec({
             fieldOrigin.testBuildString() shouldBe "^FO10,10,0"
         }
         it("uses alignment parameter correctly") {
-            ZplJustification.entries.forEach {
+            table(headers("justification"), ZplJustification.entries.toRows()).forAll {
                 fieldOrigin.copy(justification = it).testBuildString() shouldBe "^FO10,10,$it"
             }
         }

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/FontTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/FontTest.kt
@@ -4,6 +4,7 @@ import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 import com.sainsburys.k2zpl.command.options.ZplFont
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -23,12 +24,12 @@ class FontTest : DescribeSpec({
             font.testBuildString() shouldBe "^AAN,30,20"
         }
         it("correctly uses font parameter") {
-            ZplFont.entries.forEach {
+            table(headers("font"), ZplFont.entries.toRows()).forAll {
                 font.copy(font = it).testBuildString() shouldBe "^A${it}N,30,20"
             }
         }
         it("correctly uses orientation parameter") {
-            ZplFieldOrientation.entries.forEach {
+            table(headers("orientation"), ZplFieldOrientation.entries.toRows()).forAll {
                 font.copy(orientation = it).testBuildString() shouldBe "^AA${it},30,20"
             }
         }

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/MediaModeTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/MediaModeTest.kt
@@ -4,8 +4,12 @@ import com.sainsburys.k2zpl.command.options.ZplMediaMode
 import com.sainsburys.k2zpl.command.options.ZplYesNo
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.headers
+import io.kotest.data.table
 import io.kotest.matchers.shouldBe
 
 class MediaModeTest : DescribeSpec({
@@ -18,12 +22,12 @@ class MediaModeTest : DescribeSpec({
             mediaMode.testBuildString() shouldBe "^MMC,N"
         }
         it("uses mediaMode parameter properly") {
-            ZplMediaMode.entries.forEach {
+            table(headers("mediaMode"), ZplMediaMode.entries.toRows()).forAll {
                 mediaMode.copy(mediaMode = it).testBuildString() shouldBe "^MM${it.value},N"
             }
         }
         it("uses prePeelSelect parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("prePeelSelect"), ZplYesNo.entries.toRows()).forAll {
                 mediaMode.copy(prePeelSelect = it).testBuildString() shouldBe "^MMC,${it}"
             }
         }

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128Test.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128Test.kt
@@ -1,0 +1,111 @@
+package com.sainsburys.k2zpl.command.barcode
+
+import com.sainsburys.k2zpl.command.options.ZplBarCode128Mode
+import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
+import com.sainsburys.k2zpl.command.options.ZplYesNo
+import com.sainsburys.k2zpl.k2zpl
+import com.sainsburys.k2zpl.testBuildString
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.headers
+import io.kotest.data.row
+import io.kotest.data.table
+import io.kotest.matchers.shouldBe
+
+class BarCode128Test : DescribeSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val subject = BarCode128(
+        orientation = ZplFieldOrientation.NORMAL,
+        height = 10,
+        line = ZplYesNo.NO,
+        lineAbove = ZplYesNo.NO,
+        checkDigit = ZplYesNo.NO,
+        mode = ZplBarCode128Mode.NONE
+    )
+    
+    describe("BarCode128") {
+        it("outputs correct command") {
+            val result = subject.testBuildString()
+            result shouldBe "^BCN,10,N,N,N,N"
+        }
+        it("uses orientation parameter properly") {
+            ZplFieldOrientation.entries.forEach {
+                subject.copy(orientation = it).testBuildString() shouldBe "^BC${it.code},10,N,N,N,N"
+            }
+        }
+        it("uses height parameter properly") {
+            subject.copy(height = 100).testBuildString() shouldBe "^BCN,100,N,N,N,N"
+        }
+        it("uses line parameter properly") {
+            ZplYesNo.entries.forEach {
+                subject.copy(line = it).testBuildString() shouldBe "^BCN,10,${it},N,N,N"
+            }
+        }
+        it("uses lineAbove parameter properly") {
+            ZplYesNo.entries.forEach {
+                subject.copy(lineAbove = it).testBuildString() shouldBe "^BCN,10,N,${it},N,N"
+            }
+        }
+        it("uses checkDigit parameter properly") {
+            ZplYesNo.entries.forEach {
+                subject.copy(checkDigit = it).testBuildString() shouldBe "^BCN,10,N,N,${it},N"
+            }
+        }
+        it("uses mode parameter properly") {
+            ZplBarCode128Mode.entries.forEach {
+                subject.copy(mode = it).testBuildString() shouldBe "^BCN,10,N,N,N,${it}"
+            }
+        }
+        it("requires valid parameters") {
+            table(
+                headers("height"),
+                row(32001),
+                row(0),
+            ).forAll { height ->
+                shouldThrow<IllegalArgumentException> {
+                    subject.copy(
+                        height = height
+                    )
+                }
+            }
+        }
+    }
+    describe("barcode128 extension") {
+        it("outputs the correct command") {
+            val result = k2zpl {
+                barcode128(
+                    data = "1234567890",
+                    x = 10,
+                    y = 10,
+                    height = 10,
+                    checkDigit = true,
+                    lineAbove = true,
+                    interpretationLine = true,
+                    mode = ZplBarCode128Mode.UCC
+                )
+            }
+            result shouldBe """
+                ^FO10,10,0
+                ^BCN,10,Y,Y,Y,U
+                ^FD1234567890
+                ^FS
+                
+            """.trimIndent()
+        }
+        it("uses default values") {
+            val result = k2zpl {
+                barcode128(data = "1234567890", x = 10, y = 10, height = 10)
+            }
+            result shouldBe """
+                ^FO10,10,0
+                ^BCN,10,N,N,N,N
+                ^FD1234567890
+                ^FS
+                
+            """.trimIndent()
+        }
+    }
+})

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128Test.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode128Test.kt
@@ -5,6 +5,7 @@ import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 import com.sainsburys.k2zpl.command.options.ZplYesNo
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -32,7 +33,10 @@ class BarCode128Test : DescribeSpec({
             result shouldBe "^BCN,10,N,N,N,N"
         }
         it("uses orientation parameter properly") {
-            ZplFieldOrientation.entries.forEach {
+            table(
+                headers("orientation"),
+                ZplFieldOrientation.entries.map(::row)
+            ).forAll {
                 subject.copy(orientation = it).testBuildString() shouldBe "^BC${it.code},10,N,N,N,N"
             }
         }
@@ -40,22 +44,22 @@ class BarCode128Test : DescribeSpec({
             subject.copy(height = 100).testBuildString() shouldBe "^BCN,100,N,N,N,N"
         }
         it("uses line parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("line"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(line = it).testBuildString() shouldBe "^BCN,10,${it},N,N,N"
             }
         }
         it("uses lineAbove parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("lineAbove"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(lineAbove = it).testBuildString() shouldBe "^BCN,10,N,${it},N,N"
             }
         }
         it("uses checkDigit parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("checkDigit"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(checkDigit = it).testBuildString() shouldBe "^BCN,10,N,N,${it},N"
             }
         }
         it("uses mode parameter properly") {
-            ZplBarCode128Mode.entries.forEach {
+            table(headers("mode"), ZplBarCode128Mode.entries.toRows()).forAll {
                 subject.copy(mode = it).testBuildString() shouldBe "^BCN,10,N,N,N,${it}"
             }
         }

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39Test.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39Test.kt
@@ -4,6 +4,7 @@ import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 import com.sainsburys.k2zpl.command.options.ZplYesNo
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
+import com.sainsburys.k2zpl.toRows
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -31,7 +32,7 @@ class BarCode39Test : DescribeSpec({
             result shouldBe "^B3N,N,10,N,N"
         }
         it("uses orientation parameter properly") {
-            ZplFieldOrientation.entries.forEach {
+            table(headers("orientation"), ZplFieldOrientation.entries.toRows()).forAll {
                 subject.copy(orientation = it).testBuildString() shouldBe "^B3${it.code},N,10,N,N"
             }
         }
@@ -39,21 +40,21 @@ class BarCode39Test : DescribeSpec({
             subject.copy(height = 100).testBuildString() shouldBe "^B3N,N,100,N,N"
         }
         it("uses checkDigit parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("checkDigit"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(checkDigit = it).testBuildString() shouldBe "^B3N,${it},10,N,N"
             }
         }
         it("uses line parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("line"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(line = it).testBuildString() shouldBe "^B3N,N,10,${it},N"
             }
         }
         it("uses lineAbove parameter properly") {
-            ZplYesNo.entries.forEach {
+            table(headers("lineAbove"), ZplYesNo.entries.toRows()).forAll {
                 subject.copy(lineAbove = it).testBuildString() shouldBe "^B3N,N,10,N,${it}"
             }
         }
-        it("requires valid parameters") {
+        it("requires valid height parameters") {
             table(
                 headers("height"),
                 row(32001),

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39Test.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/barcode/BarCode39Test.kt
@@ -1,6 +1,5 @@
-package com.sainsburys.k2zpl.command
+package com.sainsburys.k2zpl.command.barcode
 
-import com.sainsburys.k2zpl.command.options.ZplBarcodeType
 import com.sainsburys.k2zpl.command.options.ZplFieldOrientation
 import com.sainsburys.k2zpl.command.options.ZplYesNo
 import com.sainsburys.k2zpl.k2zpl
@@ -14,75 +13,75 @@ import io.kotest.data.row
 import io.kotest.data.table
 import io.kotest.matchers.shouldBe
 
-class BarCodeTest : DescribeSpec({
+class BarCode39Test : DescribeSpec({
 
     isolationMode = IsolationMode.InstancePerLeaf
 
-    val barCode = BarCode(
-        type = ZplBarcodeType.CODE_39,
+    val subject = BarCode39(
         orientation = ZplFieldOrientation.NORMAL,
         checkDigit = ZplYesNo.NO,
         height = 10,
-        line = 7,
-        lineAbove = ZplYesNo.YES
+        line = ZplYesNo.NO,
+        lineAbove = ZplYesNo.NO
     )
 
-    describe("Barcode") {
+    describe("Barcode39") {
         it("outputs correct command") {
-            val result = barCode.testBuildString()
-            result shouldBe "^B1N,N,10,7,Y"
+            val result = subject.testBuildString()
+            result shouldBe "^B3N,N,10,N,N"
         }
         it("uses orientation parameter properly") {
             ZplFieldOrientation.entries.forEach {
-                barCode.copy(orientation = it).testBuildString() shouldBe "^B1${it.code},N,10,7,Y"
+                subject.copy(orientation = it).testBuildString() shouldBe "^B3${it.code},N,10,N,N"
             }
+        }
+        it("uses height parameter properly") {
+            subject.copy(height = 100).testBuildString() shouldBe "^B3N,N,100,N,N"
         }
         it("uses checkDigit parameter properly") {
             ZplYesNo.entries.forEach {
-                barCode.copy(checkDigit = it).testBuildString() shouldBe "^B1N,${it},10,7,Y"
+                subject.copy(checkDigit = it).testBuildString() shouldBe "^B3N,${it},10,N,N"
+            }
+        }
+        it("uses line parameter properly") {
+            ZplYesNo.entries.forEach {
+                subject.copy(line = it).testBuildString() shouldBe "^B3N,N,10,${it},N"
             }
         }
         it("uses lineAbove parameter properly") {
             ZplYesNo.entries.forEach {
-                barCode.copy(lineAbove = it).testBuildString() shouldBe "^B1N,N,10,7,${it}"
+                subject.copy(lineAbove = it).testBuildString() shouldBe "^B3N,N,10,N,${it}"
             }
         }
         it("requires valid parameters") {
             table(
-                headers("height", "line"),
-                row(32001, 1),
-                row(0, 1),
-                row(1, 0),
-                row(1, 8)
-            ).forAll { height, line ->
+                headers("height"),
+                row(32001),
+                row(0),
+            ).forAll { height ->
                 shouldThrow<IllegalArgumentException> {
-                    barCode.copy(
-                        height = height,
-                        line = line,
+                    subject.copy(
+                        height = height
                     )
                 }
             }
         }
-
     }
-    describe("barcode extension") {
+    describe("barcode39 extension") {
         it("outputs the correct command") {
             val result = k2zpl {
-                barcode(
+                barcode39(
                     data = "1234567890",
                     x = 10,
                     y = 10,
                     height = 10,
-                    lineThickness = 7,
-                    barcodeType = ZplBarcodeType.CODE_39,
-                    orientation = ZplFieldOrientation.NORMAL,
                     checkDigit = false,
                     lineAbove = true
                 )
             }
             result shouldBe """
                 ^FO10,10,0
-                ^B1N,N,10,7,Y
+                ^B3N,N,10,N,Y
                 ^FD1234567890
                 ^FS
                 
@@ -90,11 +89,11 @@ class BarCodeTest : DescribeSpec({
         }
         it("uses default values") {
             val result = k2zpl {
-                barcode(data = "1234567890", x = 10, y = 10, height = 10, lineThickness = 7)
+                barcode39(data = "1234567890", x = 10, y = 10, height = 10, interpretationLine = true)
             }
             result shouldBe """
                 ^FO10,10,0
-                ^B1N,N,10,7,N
+                ^B3N,N,10,Y,N
                 ^FD1234567890
                 ^FS
                 


### PR DESCRIPTION
Breaks out `BarCode` into interface and creates `BarCode39` and `BarCode128`. Further bar code definitions should use `BarCode` interface.