### PR TITLE
[#8] Add method to track current vertical position

### DIFF
--- a/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
@@ -20,9 +20,21 @@ class ZplBuilder {
     private var _zplDpiSetting: ZplDpiSetting = ZplDpiSetting.Unset
     private var defaultFont: Font = Font(ZplFont.A, ZplFieldOrientation.NORMAL, 30.dots, 30.dots)
 
+    /**
+     * The current vertical or Y position of the label. This can be used
+     * as needed to keep track of a label height to be used in combination
+     * with the [com.sainsburys.k2zpl.command.LabelLength] command, as well as
+     * any command that requires a Y position value.
+     */
     var verticalPosition: Int = 0
         private set
 
+    /**
+     * Advance the [verticalPosition] value by the amount specified.
+     * Can also be used in combination with the [cm], [mm], [dots] functions
+     * to indicate measurement type.
+     * @param byAmount The amount to increment the [verticalPosition] by.
+     */
     fun advancePosition(byAmount: Int) {
         verticalPosition += byAmount
     }

--- a/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/builder/ZplBuilder.kt
@@ -20,6 +20,13 @@ class ZplBuilder {
     private var _zplDpiSetting: ZplDpiSetting = ZplDpiSetting.Unset
     private var defaultFont: Font = Font(ZplFont.A, ZplFieldOrientation.NORMAL, 30.dots, 30.dots)
 
+    var verticalPosition: Int = 0
+        private set
+
+    fun advancePosition(byAmount: Int) {
+        verticalPosition += byAmount
+    }
+
     var dpiSetting: ZplDpiSetting
         get() {
             if (_zplDpiSetting == ZplDpiSetting.Unset) {

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/LabelLength.kt
@@ -1,6 +1,7 @@
 package com.sainsburys.k2zpl.command
 
 import com.sainsburys.k2zpl.builder.ZplBuilder
+import com.sainsburys.k2zpl.command.options.ZplLabelLength
 
 internal data class LabelLength(val length: Int) : ZplCommand {
     init {
@@ -12,20 +13,40 @@ internal data class LabelLength(val length: Int) : ZplCommand {
 }
 
 /**
- * Sets the length of the label.
+ * Sets the length of the label using Int.
  * @param length The length of the label.
  */
 fun ZplBuilder.labelLength(length: Int) {
-    command(LabelLength(length))
+    labelLength(ZplLabelLength.Exact(length))
+}
+
+/**
+ * Sets the length of the label using ZplLabelLength.
+ * @param length The length of the label:
+ *   - [ZplLabelLength.Exact] the exact value
+ *   - [ZplLabelLength.CurrentPosition] use [ZplBuilder.verticalPosition]
+ */
+fun ZplBuilder.labelLength(length: ZplLabelLength) {
+    when (length) {
+        ZplLabelLength.CurrentPosition -> command { LabelLength(verticalPosition) }
+        is ZplLabelLength.Exact -> command(LabelLength(length.value))
+    }
 }
 
 /**
  * Sets the length of the label by lambda
  * This allows for lazy evaluation of the length.
  * @param length lambda with context of the current [ZplBuilder]
+ * that returns an Int.
  */
-fun ZplBuilder.labelLength(length: ZplBuilder.() -> Int) {
+fun ZplBuilder.labelLength(length: ZplBuilder.() -> ZplLabelLength) {
     command {
-        LabelLength(length.invoke(this))
+        when (val result = length.invoke(this)) {
+            ZplLabelLength.CurrentPosition -> verticalPosition
+            is ZplLabelLength.Exact -> result.value
+        }.let {
+            LabelLength(it)
+        }
     }
 }
+

--- a/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplLabelLength.kt
+++ b/src/main/kotlin/com/sainsburys/k2zpl/command/options/ZplLabelLength.kt
@@ -1,0 +1,8 @@
+@file:Suppress("UNUSED")
+
+package com.sainsburys.k2zpl.command.options
+
+sealed class ZplLabelLength {
+    data class Exact(val value: Int) : ZplLabelLength()
+    data object CurrentPosition : ZplLabelLength()
+}

--- a/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
@@ -56,13 +56,8 @@ class ZplBuilderTest : DescribeSpec({
         it("adds value to the vertical position") {
             subject.advancePosition(100)
             subject.verticalPosition shouldBe 100
-        }
-        it("adds cm value to the vertical position") {
-            subject.apply {
-                subject.dpiSetting = ZplDpiSetting.DPI_203
-                advancePosition(5.cm)
-                verticalPosition shouldBe 5.cm
-            }
+            subject.advancePosition(50)
+            subject.verticalPosition shouldBe 150
         }
     }
     describe("Int mm extension") {

--- a/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
@@ -58,7 +58,11 @@ class ZplBuilderTest : DescribeSpec({
             subject.verticalPosition shouldBe 100
         }
         it("adds cm value to the vertical position") {
-            subject.verticalPosition shouldBe 100
+            subject.apply {
+                subject.dpiSetting = ZplDpiSetting.DPI_203
+                advancePosition(5.cm)
+                verticalPosition shouldBe 5.cm
+            }
         }
     }
     describe("Int mm extension") {

--- a/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/builder/ZplBuilderTest.kt
@@ -49,6 +49,18 @@ class ZplBuilderTest : DescribeSpec({
             subject.dpiSetting shouldBe ZplDpiSetting.DPI_203
         }
     }
+    describe("advancePosition") {
+        it("defaults to zero") {
+            subject.verticalPosition shouldBe 0
+        }
+        it("adds value to the vertical position") {
+            subject.advancePosition(100)
+            subject.verticalPosition shouldBe 100
+        }
+        it("adds cm value to the vertical position") {
+            subject.verticalPosition shouldBe 100
+        }
+    }
     describe("Int mm extension") {
         it("throws an appropriate exception when no ZplDpiSetting") {
             shouldThrow<IllegalStateException> {

--- a/src/test/kotlin/com/sainsburys/k2zpl/command/LabelLengthTest.kt
+++ b/src/test/kotlin/com/sainsburys/k2zpl/command/LabelLengthTest.kt
@@ -1,5 +1,6 @@
 package com.sainsburys.k2zpl.command
 
+import com.sainsburys.k2zpl.command.options.ZplLabelLength
 import com.sainsburys.k2zpl.k2zpl
 import com.sainsburys.k2zpl.testBuildString
 import io.kotest.assertions.throwables.shouldThrow
@@ -39,13 +40,41 @@ class LabelLengthTest : DescribeSpec({
             }
             result shouldBe "^LL1000\n"
         }
-        it("outputs correct command when using lambda") {
+        it("outputs correct command when using Exact") {
+            val result = k2zpl {
+                labelLength(ZplLabelLength.Exact(100))
+            }
+            result shouldBe "^LL100\n"
+        }
+        it("outputs correct command when using lambda Exact") {
             var size = 100
             val result = k2zpl {
                 labelLength {
-                    size
+                    ZplLabelLength.Exact(size)
                 }
                 size += 100
+            }
+            result shouldBe "^LL200\n"
+        }
+        it("outputs correct command when using CurrentPosition") {
+            val result = k2zpl {
+                labelLength(ZplLabelLength.CurrentPosition)
+                advancePosition(200)
+            }
+            result shouldBe "^LL200\n"
+        }
+        it("outputs correct command when using CurrentPosition with multiple advancePosition") {
+            val result = k2zpl {
+                advancePosition(200)
+                labelLength(ZplLabelLength.CurrentPosition)
+                advancePosition(200)
+            }
+            result shouldBe "^LL400\n"
+        }
+        it("outputs correct command when using lambda CurrentPosition") {
+            val result = k2zpl {
+                labelLength { ZplLabelLength.CurrentPosition }
+                advancePosition(200)
             }
             result shouldBe "^LL200\n"
         }


### PR DESCRIPTION
- Adds `verticalPosition` in `ZplBuilder` to allow tracking of position
- Add `advancePosition` to allow control of `currentPosition`
- Update use of `labelLength` to take either `Exact` or `CurrentPosition` values.